### PR TITLE
Remove duplicate regions based on their positions

### DIFF
--- a/expreg.el
+++ b/expreg.el
@@ -86,7 +86,7 @@
   (require 'cl-lib))
 (require 'seq)
 
-;;; Cutom options and variables
+;;; Custom options and variables
 
 (defvar-local expreg-functions
   '( expreg--subword expreg--word expreg--list expreg--string
@@ -106,7 +106,7 @@ scan-error, like end-of-buffer, or unbalanced parentheses, etc.")
   "If t, restore the point when quitting with ‘keyboard-quit’.
 
 By default, when user presses quit when expanding, nothing special
-happends: the region is deactivated and the point stays at where it is.
+happens: the region is deactivated and the point stays at where it is.
 But if this option is turned on, Emacs moves point back to where it was
 when user first started calling ‘expreg-expand’.")
 

--- a/expreg.el
+++ b/expreg.el
@@ -261,7 +261,7 @@ This is used to restore point when canceling the expansion when
                             expreg-functions))
            (regions (expreg--filter-regions regions orig))
            (regions (expreg--sort-regions regions))
-           (regions (cl-remove-duplicates regions :test #'equal)))
+           (regions (cl-remove-duplicates regions :test #'equal :key #'cdr)))
       (setq-local expreg--next-regions regions)))
 
   ;; Go past all the regions that are smaller than the current region,


### PR DESCRIPTION
Hello, thank you for this package!

Currently, duplicate regions are removed by testing the entire `(FN . (BEG . END))` form. However, a custom expansion function might return identical region positions as those produced by other functions. Since the forms will have different `FN` identifiers, the duplicate regions won't be removed from the list, making the expansion or contraction of a region appear to have ended as the same region range will be set again.

This PR addresses this issue by modifying the test for duplicates to consider only the `(BEG . END)` part of the region forms. This ensures that when multiple expansion functions produce the same region positions, only one of them is kept.