### PR TITLE
Call push-mark before set-mark

### DIFF
--- a/expreg.el
+++ b/expreg.el
@@ -229,6 +229,10 @@ The shape is (POS . (BEG . END)).
 This is used to restore point when canceling the expansion when
 ‘expreg-restore-point-on-quit’ is enabled.")
 
+(defvar-local expreg--mark-pushed nil
+  "Whether or not a mark has been pushed during the current
+command sequence.")
+
 (defun expreg--keyboard-quit-advice ()
   "Restores point when ‘keyboard-quit’ is called."
   (interactive)
@@ -242,6 +246,16 @@ This is used to restore point when canceling the expansion when
     (goto-char (car expreg--initial-point-and-last-range)))
   (setq expreg--initial-point-and-last-range nil))
 
+(defun expreg--update-mark (pos)
+  "If expreg has not yet set a mark during the current command
+sequence, then push one. On subsequent calls during the same
+sequence, update the existing mark."
+  (if (not expreg--mark-pushed)
+      (progn
+        (push-mark pos t t)
+        (setq-local expreg--mark-pushed t))
+    (set-mark pos)))
+
 ;;;###autoload
 (defun expreg-expand ()
   "Expand region."
@@ -254,6 +268,7 @@ This is used to restore point when canceling the expansion when
                       (cddr (car expreg--prev-regions)))))
     (setq-local expreg--next-regions nil)
     (setq-local expreg--prev-regions nil)
+    (setq-local expreg--mark-pushed nil)
     (setq-local expreg--initial-point-and-last-range (cons (point-marker) nil))
     (when expreg-restore-point-on-quit
       ;; We have to add the advice using :before. :after doesn’t work
@@ -288,7 +303,7 @@ This is used to restore point when canceling the expansion when
   ;; Expand to the next expansion.
   (when expreg--next-regions
     (let ((region (pop expreg--next-regions)))
-      (set-mark (cddr region))
+      (expreg--update-mark (cddr region))
       (goto-char (cadr region))
       (push region expreg--prev-regions)
       (unless transient-mark-mode
@@ -310,7 +325,7 @@ This is used to restore point when canceling the expansion when
              (length> expreg--prev-regions 1))
 
     (push (pop expreg--prev-regions) expreg--next-regions)
-    (set-mark (cddr (car expreg--prev-regions)))
+    (expreg--update-mark (cddr (car expreg--prev-regions)))
     (goto-char (cadr (car expreg--prev-regions))))
 
   (setcdr expreg--initial-point-and-last-range


### PR DESCRIPTION
Hi there. expreg works great for me overall, but I ran into a quirk. Long story short, I noticed expreg could stomp on marks left by other commands. Take this sequence of events:

1. Start an isearch at point A.
2. Use isearch to get to point B. isearch leaves a mark at point A where the search began.
3. Use expreg to mark a sexp to be copied/killed.
4. C-u C-SPC one or more times to pop marks until arriving back at point A.

The problem is, during step 3 expreg calls set-mark which overwrites the most recent mark - in this case the one pushed by isearch. And so you can't get back to point A in step 4.

I fixed this by having expreg first call push-mark when it needs to record a mark. After that, it can call set-mark to update it. This lets it have its own mark to manipulate, and isearch's mark is left untouched